### PR TITLE
Emit dimensions in pixel in resize event

### DIFF
--- a/src/GridItem.vue
+++ b/src/GridItem.vue
@@ -522,7 +522,7 @@
                 this.lastH = y;
 
                 if (this.innerW !== pos.w || this.innerH !== pos.h) {
-                    this.$emit("resize", this.i, pos.h, pos.w);
+                    this.$emit("resize", this.i, pos.h, pos.w, newSize.height, newSize.width);
                 }
                 if (event.type === "resizeend" && (this.previousW !== this.innerW || this.previousH !== this.innerH)) {
                     this.$emit("resized", this.i, pos.h, pos.w, newSize.height, newSize.width);


### PR DESCRIPTION
It's often useful to have the dimensions of the placeholder in resize event because it allows us to resize the content when the user is resizing an item in real-time.